### PR TITLE
Fix "null" for empty buffer hex representation

### DIFF
--- a/tchannel-session-tracker.js
+++ b/tchannel-session-tracker.js
@@ -196,11 +196,15 @@ function inspectArgument(name, argument) {
 };
 
 function hex(value) {
-    return hexer(value, {
-        prefix: '  ',
-        gutter: 4, // maximum frame length is 64k so FFFF
-        renderHuman: renderByte
-    });
+    if (value.length === 0) {
+        return '';
+    } else {
+        return hexer(value, {
+            prefix: '  ',
+            gutter: 4, // maximum frame length is 64k so FFFF
+            renderHuman: renderByte
+        });
+    }
 }
 
 function renderByte(c) {


### PR DESCRIPTION
Hexer currently returns "null" if the given buffer is empty.
With this change an empty buffer is reported as a blank line.

I considered putting "empty" in the blank space, but it does not align
well with the gutter.

Fixes #6

review @rf @jcorbin 
