### PR TITLE
do not print frame parse errors in service name filter mode

### DIFF
--- a/tchannel-session-tracker.js
+++ b/tchannel-session-tracker.js
@@ -181,6 +181,10 @@ function handleError(error) {
         return self.stopTracking();
     }
 
+    if (self.serviceNames && self.serviceNames.length > 0) {
+        return self.stopTracking();
+    }
+
     console.log(ansi.red(sprintf(
         'session=%d %s %s %s frame parse error',
         self.sessionNumber,


### PR DESCRIPTION
r: @jcorbin @kriskowal