### PR TITLE
filter the arg1 pairs

### DIFF
--- a/tchannel-session-tracker.js
+++ b/tchannel-session-tracker.js
@@ -140,12 +140,21 @@ function handleFrame(frame) {
         }
     }
 
-    if (self.arg1Methods && frame && frame.body) {
-        var arg1 = frame.body.args &&
-            frame.body.args[1] &&
-            String(frame.body.args[1]);
+    // apply the filter on arg1
+    if (self.arg1Methods) {
+        if (frame && frame.body && frame.body.args) {
+            var name = frame.body.args[0];
 
-        if (self.arg1Methods.indexOf(arg1) < 0) {
+            if (!self.arg1Methods[name] &&
+                !self.arg1Methods[frame.id.toString()]) {
+                return;
+            }
+
+            self.arg1Methods[name] = frame.id;
+            self.arg1Methods[frame.id.toString()] = frame.id;
+
+        } else {
+            // filter out frames not related to arg1
             return;
         }
     }
@@ -177,7 +186,7 @@ TChannelSessionTracker.prototype.handleError =
 function handleError(error) {
     var self = this;
 
-    if (self.arg1Methods && self.arg1Methods.length > 0) {
+    if (self.arg1Methods) {
         return self.stopTracking();
     }
 

--- a/tchannel-session-tracker.js
+++ b/tchannel-session-tracker.js
@@ -146,12 +146,12 @@ function handleFrame(frame) {
             var name = frame.body.args[0];
 
             if (!self.arg1Methods[name] &&
-                !self.arg1Methods[frame.id.toString()]) {
+                !self.arg1Methods[frame.id]) {
                 return;
             }
 
             self.arg1Methods[name] = frame.id;
-            self.arg1Methods[frame.id.toString()] = frame.id;
+            self.arg1Methods[frame.id] = frame.id;
 
         } else {
             // filter out frames not related to arg1

--- a/tchannel-tracker.js
+++ b/tchannel-tracker.js
@@ -51,7 +51,7 @@ function TChannelTracker(opts) {
 
     if (opts.arg1Methods) {
         self.arg1Methods = {};
-        opts.arg1Methods.forEach(function(name) {
+        opts.arg1Methods.forEach(function arr2obj(name) {
             self.arg1Methods[name] = -1;
         });
 
@@ -159,7 +159,7 @@ function handleTcpSession(tcpSession, iface) {
         // clean up the arg1 methods table
         if (self.arg1Methods) {
             self.arg1Methods = {};
-            self.arg1MethodsArray.forEach(function(name) {
+            self.arg1MethodsArray.forEach(function arr2obj(name) {
                 self.arg1Methods[name] = -1;
             });
         }

--- a/tchannel-tracker.js
+++ b/tchannel-tracker.js
@@ -48,6 +48,15 @@ function TChannelTracker(opts) {
     self.alwaysShowHex = opts.alwaysShowHex;
     self.bufferSize = opts.bufferSize; // in bytes
     self.nextSessionNumber = 0;
+
+    if (opts.arg1Methods) {
+        self.arg1Methods = {};
+        opts.arg1Methods.forEach(function(name) {
+            self.arg1Methods[name] = -1;
+        });
+
+        self.arg1MethodsArray = opts.arg1Methods;
+    }
 }
 
 function portPredicate(port) {
@@ -107,7 +116,8 @@ function handleTcpSession(tcpSession, iface) {
         tcpSession: tcpSession,
         serviceNames: self.serviceNames,
         alwaysShowFrameDump: self.alwaysShowFrameDump,
-        alwaysShowHex: self.alwaysShowHex
+        alwaysShowHex: self.alwaysShowHex,
+        arg1Methods: self.arg1Methods
     });
 
     var outgoingSessionTracker = new TChannelSessionTracker({
@@ -117,7 +127,8 @@ function handleTcpSession(tcpSession, iface) {
         tcpSession: tcpSession,
         serviceNames: self.serviceNames,
         alwaysShowFrameDump: self.alwaysShowFrameDump,
-        alwaysShowHex: self.alwaysShowHex
+        alwaysShowHex: self.alwaysShowHex,
+        arg1Methods: self.arg1Methods
     });
 
     tcpSession.on('data send', handleDataSend);
@@ -144,6 +155,13 @@ function handleTcpSession(tcpSession, iface) {
         tcpSession.removeListener('data recv', handleDataRecv);
         incomingSessionTracker.end();
         outgoingSessionTracker.end();
-    }
 
+        // clean up the arg1 methods table
+        if (self.arg1Methods) {
+            self.arg1Methods = {};
+            self.arg1MethodsArray.forEach(function(name) {
+                self.arg1Methods[name] = -1;
+            });
+        }
+    }
 };


### PR DESCRIPTION
r @Raynos @kriskowal 

This change allows filtering arg1 by paris. In the example below, tcap cannot filter out the second frame before the change. After the change, tcap can filter out both frames.

session=0 127.0.0.1:55274 --> 127.0.0.1:4040 frame=2 type=0x03
CALL REQUEST id=0x0002 (2) service="" flags=0x00 ttl=0x1388 (5000)
headers
  re:
tracing: spanid=0000000000000000 parentid=0000000000000000 traceid=0000000000000000 flags=0x00
args[0]
    00: 6675 6e63 31                             func1
args[1]
    00: 6172 6720 31                             arg 1
args[2]
    00: 6172 6720 32                             arg 2

session=0 127.0.0.1:55274 <-- 127.0.0.1:4040 frame=2 type=0x04
CALL RESPONSE id=0x0002 (2) flags=0x00
tracing: spanid=0000000000000000 parentid=0000000000000000 traceid=0000000000000000 flags=0x00
args[0]
    00:                                          empty
args[1]
    00: 7265 7375 6c74                           result
args[2]
    00: 696e 6465 6564 2069 7420 6469 64         indeed it did