### PR TITLE
filter by response & three other small features

### DIFF
--- a/bin/tcap.js
+++ b/bin/tcap.js
@@ -54,6 +54,9 @@ function main(argv) {
         .option('-1 --arg1 <arg1-method>',
             'arg1 method or methods to show ' +
             '(default: all arg1 methods shown)', collect, [])
+        .option('-r --response <response>',
+            'responses to show: O[K], N[otOk], E[rror] ' +
+            '(default: all shown)', collect, [])
         .option('-b --buffer-size <mb>',
             'size in MiB to buffer between libpcap and app ' +
             '(default: 10)')
@@ -78,6 +81,8 @@ function main(argv) {
         filter: commander.filter,
         serviceNames: commander.service.length ? commander.service : null,
         arg1Methods: commander.arg1.length ? commander.arg1 : null,
+        responseStatuses: commander.response.length ?
+            commander.response : null,
         alwaysShowFrameDump: commander.inspect,
         alwaysShowHex: commander.hex,
         bufferSize: bufferSizeMb * 1024 * 1024

--- a/tchannel-tracker.js
+++ b/tchannel-tracker.js
@@ -28,7 +28,6 @@ var ansi = require('chalk');
 var events = require('events');
 var TChannelSessionTracker = require('./tchannel-session-tracker');
 var TchannelTypes = require('./tchannel-types');
-var FrameType = TchannelTypes.FrameType;
 var ResponseType = TchannelTypes.ResponseType;
 
 module.exports = TChannelTracker;
@@ -61,31 +60,7 @@ function TChannelTracker(opts) {
         self.arg1MethodsArray = opts.arg1Methods;
     }
 
-    if (opts.responseStatuses) {
-        self.responseStatuses = [];
-        opts.responseStatuses.forEach(function createRSTable(name) {
-            switch (name.toLowerCase()) {
-                case 'o':
-                case 'ok':
-                    self.responseStatuses[ResponseType.Ok] = 'Ok';
-                    break;
-                case 'n':
-                case 'notok':
-                    self.responseStatuses[ResponseType.NotOk] = 'NotOk';
-                    break;
-                case 'e':
-                case 'error':
-                    self.responseStatuses[FrameType.Error] = 'Error';
-                    break;
-                default:
-                    console.log(ansi.red(
-                    ansi.bold('Warning: wrong response status ' +
-                              'in command options: \'-r ' +
-                              name + '\'')));
-                    break;
-            }
-        });
-    }
+    self.responseStatuses = opts.responseStatuses;
 }
 
 function portPredicate(port) {

--- a/tchannel-tracker.js
+++ b/tchannel-tracker.js
@@ -27,6 +27,9 @@ var util = require('util');
 var ansi = require('chalk');
 var events = require('events');
 var TChannelSessionTracker = require('./tchannel-session-tracker');
+var TchannelTypes = require('./tchannel-types');
+var FrameType = TchannelTypes.FrameType;
+var ResponseType = TchannelTypes.ResponseType;
 
 module.exports = TChannelTracker;
 function TChannelTracker(opts) {
@@ -56,6 +59,32 @@ function TChannelTracker(opts) {
         });
 
         self.arg1MethodsArray = opts.arg1Methods;
+    }
+
+    if (opts.responseStatuses) {
+        self.responseStatuses = [];
+        opts.responseStatuses.forEach(function createRSTable(name) {
+            switch (name.toLowerCase()) {
+                case 'o':
+                case 'ok':
+                    self.responseStatuses[ResponseType.Ok] = 'Ok';
+                    break;
+                case 'n':
+                case 'notok':
+                    self.responseStatuses[ResponseType.NotOk] = 'NotOk';
+                    break;
+                case 'e':
+                case 'error':
+                    self.responseStatuses[FrameType.Error] = 'Error';
+                    break;
+                default:
+                    console.log(ansi.red(
+                    ansi.bold('Warning: wrong response status ' +
+                              'in command options: \'-r ' +
+                              name + '\'')));
+                    break;
+            }
+        });
     }
 }
 
@@ -117,7 +146,8 @@ function handleTcpSession(tcpSession, iface) {
         serviceNames: self.serviceNames,
         alwaysShowFrameDump: self.alwaysShowFrameDump,
         alwaysShowHex: self.alwaysShowHex,
-        arg1Methods: self.arg1Methods
+        arg1Methods: self.arg1Methods,
+        responseStatuses: self.responseStatuses
     });
 
     var outgoingSessionTracker = new TChannelSessionTracker({
@@ -128,7 +158,8 @@ function handleTcpSession(tcpSession, iface) {
         serviceNames: self.serviceNames,
         alwaysShowFrameDump: self.alwaysShowFrameDump,
         alwaysShowHex: self.alwaysShowHex,
-        arg1Methods: self.arg1Methods
+        arg1Methods: self.arg1Methods,
+        responseStatuses: self.responseStatuses
     });
 
     tcpSession.on('data send', handleDataSend);

--- a/tchannel-types.js
+++ b/tchannel-types.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports.FrameType = {
+	'InitReq': 0x01,
+	'InitRes': 0x02,
+	'CallReq': 0x03,
+	'CallRes': 0x04,
+	'CallReqContinue': 0x13,
+	'CallResContinue': 0x14,
+	'Cancel': 0xc0,
+	'Claim': 0xc1,
+	'PingReq': 0xd0,
+	'PingRes': 0xd1,
+	'Error': 0xff
+};
+
+var frameNameByType = [];
+frameNameByType[0x01] = 'init request';
+frameNameByType[0x02] = 'init response';
+frameNameByType[0x03] = 'call request';
+frameNameByType[0x04] = 'call response';
+frameNameByType[0x13] = 'request continue';
+frameNameByType[0x14] = 'response continue';
+frameNameByType[0xc0] = 'cancel';
+frameNameByType[0xc1] = 'claim';
+frameNameByType[0xd0] = 'ping request';
+frameNameByType[0xd1] = 'ping response';
+frameNameByType[0xff] = 'error';
+module.exports.FrameNameByType = frameNameByType;
+
+module.exports.ErrorType = {
+	'Invalid': 0x00,
+	'Timeout': 0x01,
+	'Cancelled': 0x02,
+	'Busy': 0x03,
+	'Declined': 0x04,
+	'UnexpectedError': 0x05,
+	'BadRequest': 0x06,
+	'NetworkError': 0x07,
+	'FatalProtocolError': 0xff
+};
+
+var errorNameByType = [];
+errorNameByType[0x00] = 'Invalid';
+errorNameByType[0x01] = 'Timeout';
+errorNameByType[0x02] = 'Cancelled';
+errorNameByType[0x03] = 'Busy';
+errorNameByType[0x04] = 'Declined';
+errorNameByType[0x05] = 'UnexpectedError';
+errorNameByType[0x06] = 'BadRequest';
+errorNameByType[0x07] = 'NetworkError';
+errorNameByType[0xff] = 'FatalProtocolError';
+module.exports.ErrorNameByType = errorNameByType;
+
+module.exports.ResponseType = {
+	'Ok': 0x00,
+	'NotOk': 0x01
+};
+
+var responseNameByType = [];
+responseNameByType[0x00] = 'Ok';
+responseNameByType[0x01] = 'NotOk';
+module.exports.ResponseNameByType = responseNameByType;

--- a/tchannel-types.js
+++ b/tchannel-types.js
@@ -20,20 +20,6 @@
 
 'use strict';
 
-module.exports.FrameType = {
-	'InitReq': 0x01,
-	'InitRes': 0x02,
-	'CallReq': 0x03,
-	'CallRes': 0x04,
-	'CallReqContinue': 0x13,
-	'CallResContinue': 0x14,
-	'Cancel': 0xc0,
-	'Claim': 0xc1,
-	'PingReq': 0xd0,
-	'PingRes': 0xd1,
-	'Error': 0xff
-};
-
 var frameNameByType = [];
 frameNameByType[0x01] = 'init request';
 frameNameByType[0x02] = 'init response';
@@ -47,30 +33,6 @@ frameNameByType[0xd0] = 'ping request';
 frameNameByType[0xd1] = 'ping response';
 frameNameByType[0xff] = 'error';
 module.exports.FrameNameByType = frameNameByType;
-
-module.exports.ErrorType = {
-	'Invalid': 0x00,
-	'Timeout': 0x01,
-	'Cancelled': 0x02,
-	'Busy': 0x03,
-	'Declined': 0x04,
-	'UnexpectedError': 0x05,
-	'BadRequest': 0x06,
-	'NetworkError': 0x07,
-	'FatalProtocolError': 0xff
-};
-
-var errorNameByType = [];
-errorNameByType[0x00] = 'Invalid';
-errorNameByType[0x01] = 'Timeout';
-errorNameByType[0x02] = 'Cancelled';
-errorNameByType[0x03] = 'Busy';
-errorNameByType[0x04] = 'Declined';
-errorNameByType[0x05] = 'UnexpectedError';
-errorNameByType[0x06] = 'BadRequest';
-errorNameByType[0x07] = 'NetworkError';
-errorNameByType[0xff] = 'FatalProtocolError';
-module.exports.ErrorNameByType = errorNameByType;
 
 module.exports.ResponseType = {
 	'Ok': 0x00,


### PR DESCRIPTION
r @Raynos @kriskowal 

Four changes:
1. add response status
Before: session=0 127.0.0.1:56901 --> 127.0.0.1:4040 frame=1 type=0x04
After: session=0 127.0.0.1:56901 --> 127.0.0.1:4040 frame=1 type=0x04 NotOk

2. add the message section if it is available int the frame, e.g.,
session=0 127.0.0.1:56775 <-- 127.0.0.1:4040 frame=2 type=0xff
ERROR[BadRequest] id=0x0002 (2)
tracing: spanid=0000000000000000 parentid=0000000000000000 traceid=0000000000000000 flags=0x00
message
    00: 2121 2121 216e 6f74 204f 4b21 2121 21    !!!!!not OK!!!!

3. add the error type for error responses. The example is shown up, i.e., ERROR[BadRequest]

4. Add a new filter: filter by response type: Ok, NotOk, and Error.