### PR TITLE
support port range

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Uses pcap to inspect tchannel traffic over a network interface.
     -h, --help                   output usage information
     -V, --version                output the version number
     -i --interface <interface>   network interface interfaces (defaults to first with an address)
-    -p --port <port>             a port or ports to track
+    -p --port <port>             a port to track or use "port1-port2" for a range of ports to track between port1 and port2
     -f --filter <filter>         packet filter in pcap-filter(7) syntax (default: all TCP packets on port 4040)
     -s --service <service-name>  service name or names to show (default: all services shown)
     -t --thrift <thrift>         path of the directory for thrift spec files

--- a/bin/tcap.js
+++ b/bin/tcap.js
@@ -50,7 +50,7 @@ function main(argv) {
             'network interface interfaces ' +
             '(defaults to first with an address)', collect, [])
         .option('-p --port <port>',
-            'a port or ports to track', collect, [])
+            'a port to track or use "port1-port2" for a range of ports to track between port1 and port2', collect, [])
         .option('-f --filter <filter>',
             'packet filter in pcap-filter(7) syntax ' +
             '(default: all TCP packets on port 4040)')

--- a/tchannel-tracker.js
+++ b/tchannel-tracker.js
@@ -37,8 +37,7 @@ function TChannelTracker(opts) {
 
     var ports = opts.ports.slice();
     if (ports.length) {
-        self.pcapFilter += ' and (' +
-            ports.map(portPredicate).join(' or ') + ')';
+        self.pcapFilter += ' and (' + portFilters(ports) + ')';
     } else if (!/\bport\b/.test(self.pcapFilter)) {
         self.pcapFilter += ' and port 4040';
     }
@@ -53,8 +52,22 @@ function TChannelTracker(opts) {
     self.color = opts.color
 }
 
-function portPredicate(port) {
-    return 'port ' + port;
+function portFilters(ports) {
+    var filter = '';
+    for (var i = 0; i < ports.length; i++) {
+        var port = ports[i];
+        if (port.indexOf('-') === -1) {
+            filter += 'port ' + port;
+        } else {
+            filter += 'portrange ' + port;
+        }
+
+        if (i !== ports.length - 1) {
+            filter += ' or ';
+        }
+    }
+
+    return filter;
 }
 
 util.inherits(TChannelTracker, events.EventEmitter);


### PR DESCRIPTION
r @kriskowal @rf @anson627 
cc @blampe 

node tcap.js -i lo0 -i en0 -p 4040 -p 4041 -p 8065 -p 4000-6000
listening on interface lo0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
listening on interface en0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
session=0 started src=127.0.0.1:64548 --> dst=127.0.0.1:5001 on lo0
session=0 127.0.0.1:64548 --> 127.0.0.1:5001 frame=1 type=0x01
INIT REQUEST id=0x0001 (1) version=2
headers
  host_port: 0.0.0.0:0
  process_name: node[54366]

session=0 127.0.0.1:64548 <-- 127.0.0.1:5001 frame=1 type=0x02
INIT RESPONSE id=0x0001 (1) version=2
headers
  host_port: 127.0.0.1:5001
  process_name: node[54366]

session=0 127.0.0.1:64548 --> 127.0.0.1:5001 frame=2 type=0x03
CALL REQUEST id=0x0002 (2) service="server" flags=0x00 ttl=0x05dc (1500)
headers
  cn: example-client
  as: raw
  re: c
tracing: spanid=70bc3db9675f4782 parentid=0000000000000000 traceid=70bc3db9675f4782 flags=0x00
args[0]
    00: 6675 6e63 31                             func1
args[1]
    00: 6172 6720 31                             arg 1
args[2]
    00: 6172 6720 32                             arg 2

session=0 127.0.0.1:64548 --> 127.0.0.1:5001 frame=3 type=0x03
CALL REQUEST id=0x0003 (3) service="server" flags=0x00 ttl=0x0064 (100)
headers
  cn: example-client
  as: raw
  re: c
tracing: spanid=ef6a8e2729fb8e38 parentid=0000000000000000 traceid=ef6a8e2729fb8e38 flags=0x00
args[0]
    00: 6675 6e63 32                             func2
args[1]
    00: 6172 6720 31                             arg 1
args[2]
    00: 6172 6720 32                             arg 2

session=0 127.0.0.1:64548 <-- 127.0.0.1:5001 frame=3 type=0x04 NotOk
CALL RESPONSE id=0x0003 (3) flags=0x00
headers
  as: raw
tracing: spanid=ef6a8e2729fb8e38 parentid=0000000000000000 traceid=ef6a8e2729fb8e38 flags=0x00
args[0]
    00:                                          empty
args[1]
    00:                                          empty
args[2]
    00: 6974 2066 6169 6c65 64                   it failed

session=0 127.0.0.1:64548 <-- 127.0.0.1:5001 frame=2 type=0x04 Ok
CALL RESPONSE id=0x0002 (2) flags=0x00
headers
  as: raw
tracing: spanid=70bc3db9675f4782 parentid=0000000000000000 traceid=70bc3db9675f4782 flags=0x00
args[0]
    00:                                          empty
args[1]
    00: 7265 7375 6c74                           result
args[2]
    00: 696e 6465 6564 2069 7420 6469 64         indeed it did

session=0 ended src=127.0.0.1:64548 --> dst=127.0.0.1:5001 on lo0