### PR TITLE
exclusion filters for service names and arg1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Uses pcap to inspect tchannel traffic over a network interface.
     -i --interface <interface>   network interface interfaces (defaults to first with an address)
     -p --port <port>             a port to track or use "port1-port2" for a range of ports to track between port1 and port2
     -f --filter <filter>         packet filter in pcap-filter(7) syntax (default: all TCP packets on port 4040)
-    -s --service <service-name>  service name or names to show (default: all services shown)
+    -s --service <service-name>  service name or names to show (default: all services shown), or
+                                 use "~service-name" to exclude the service
     -t --thrift <thrift>         path of the directory for thrift spec files
-    -1 --arg1 <arg1-method>      arg1 method or methods to show (default: all arg1 methods shown)
+    -1 --arg1 <arg1-method>      arg1 method or methods to show (default: all arg1 methods shown), or
+                                 use "~arg1-method" to exclude the arg1
     --m1                         show arg1 name in call responses
     -r --response <response>     responses to show: O[K], N[otOk], E[rror] (default: all shown)
     -b --buffer-size <mb>        size in MiB to buffer between libpcap and app (default: 10)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Uses pcap to inspect tchannel traffic over a network interface.
     -p --port <port>             a port to track or use "port1-port2" for a range of ports to track between port1 and port2
     -f --filter <filter>         packet filter in pcap-filter(7) syntax (default: all TCP packets on port 4040)
     -s --service <service-name>  service name or names to show (default: all services shown), or
-                                 use "~service-name" to exclude the service
+                                 use "-service-name" to exclude the service
     -t --thrift <thrift>         path of the directory for thrift spec files
     -1 --arg1 <arg1-method>      arg1 method or methods to show (default: all arg1 methods shown), or
-                                 use "~arg1-method" to exclude the arg1
+                                 use "-arg1-method" to exclude the arg1
     --m1                         show arg1 name in call responses
     -r --response <response>     responses to show: O[K], N[otOk], E[rror] (default: all shown)
     -b --buffer-size <mb>        size in MiB to buffer between libpcap and app (default: 10)

--- a/bin/tcap.js
+++ b/bin/tcap.js
@@ -61,8 +61,7 @@ function main(argv) {
         .option('-t --thrift <thrift>',
             'path of the directory for thrift spec files')
         .option('-1 --arg1 <arg1-method>',
-            'arg1 method or methods to show ' +
-            '(default: all arg1 methods shown)'  + newline +
+            'arg1 method or methods to show (default: all arg1 methods shown), or'  + newline +
             'use "~arg1-method" to exclude the arg1', collect, [])
         .option('--m1',
             'show arg1 name in call responses')

--- a/bin/tcap.js
+++ b/bin/tcap.js
@@ -57,12 +57,12 @@ function main(argv) {
             '(default: all TCP packets on port 4040)')
         .option('-s --service <service-name>',
             'service name or names to show (default: all services shown), or' + newline +
-            'use "~service-name" to exclude the service', collect, [])
+            'use "-service-name" to exclude the service', collect, [])
         .option('-t --thrift <thrift>',
             'path of the directory for thrift spec files')
         .option('-1 --arg1 <arg1-method>',
             'arg1 method or methods to show (default: all arg1 methods shown), or'  + newline +
-            'use "~arg1-method" to exclude the arg1', collect, [])
+            'use "-arg1-method" to exclude the arg1', collect, [])
         .option('--m1',
             'show arg1 name in call responses')
         .option('-r --response <response>',

--- a/bin/tcap.js
+++ b/bin/tcap.js
@@ -45,6 +45,7 @@ function main(argv) {
         return xs;
     }
 
+    var newline = '\n                             ';
     commander.version(require('../package.json').version)
         .option('-i --interface <interface>',
             'network interface interfaces ' +
@@ -55,13 +56,14 @@ function main(argv) {
             'packet filter in pcap-filter(7) syntax ' +
             '(default: all TCP packets on port 4040)')
         .option('-s --service <service-name>',
-            'service name or names to show ' +
-            '(default: all services shown)', collect, [])
+            'service name or names to show (default: all services shown), or' + newline +
+            'use "~service-name" to exclude the service', collect, [])
         .option('-t --thrift <thrift>',
             'path of the directory for thrift spec files')
         .option('-1 --arg1 <arg1-method>',
             'arg1 method or methods to show ' +
-            '(default: all arg1 methods shown)', collect, [])
+            '(default: all arg1 methods shown)'  + newline +
+            'use "~arg1-method" to exclude the arg1', collect, [])
         .option('--m1',
             'show arg1 name in call responses')
         .option('-r --response <response>',

--- a/frame-filters.js
+++ b/frame-filters.js
@@ -178,7 +178,7 @@ Arg1Filter.prototype.take = function take(filter) {
     }
 };
 
-Arg1Filter.prototype.process = function processEx(handle, frame) {
+Arg1Filter.prototype.process = function process(handle, frame) {
     var self = this;
     var inclusive = !!self.inclusive;
 

--- a/frame-filters.js
+++ b/frame-filters.js
@@ -21,6 +21,7 @@
 /*eslint no-console:0 max-statements: [1, 30]*/
 
 'use strict';
+var assert = require('assert');
 
 //
 // TODO
@@ -30,6 +31,24 @@
 //
 var TChannelFrame = require('tchannel/v2/index');
 var FrameTypes = TChannelFrame.Types;
+
+
+function inclusionValidate(filters, filterName) {
+    var inclusion;
+    var exclusion;
+    for (var i = 0; i < filters.length; i++) {
+        var name = filters[i];
+        if (name.indexOf('~') === 0) {
+            exclusion = true;
+        } else {
+            inclusion = true;
+        }
+
+        assert(!exclusion || !inclusion, filterName + ' cannot have a mix of inclusions and exclusions');
+    }
+
+    return inclusion;
+}
 
 module.exports = TChannelFrameFilters;
 function TChannelFrameFilters() {
@@ -97,13 +116,20 @@ ServicerNameFilter.prototype.take = function take(filter) {
         return false;
     } else {
         self.serviceNames = filter;
+
+        // validate
+        self.inclusion = inclusionValidate(self.serviceNames, 'Service name filters');
         return true;
     }
 };
 
 ServicerNameFilter.prototype.process = function process(handle, frame) {
     var self = this;
+    var inclusion = !!self.inclusion;
     var serviceName = frame.body.service;
+    if (serviceName && !inclusion) {
+        serviceName = '~' + serviceName;
+    }
 
     if (!handle.serviceName) {
         handle.serviceName = {};
@@ -112,23 +138,23 @@ ServicerNameFilter.prototype.process = function process(handle, frame) {
     var ids = handle.serviceName;
     if (!serviceName) {
         if (!ids[frame.id]) {
-            return false;
+            return !inclusion;
         }
 
         if (shouldRemove(frame)) {
             delete ids[frame.id];
         }
 
-        return true;
+        return inclusion;
     }
 
     if (self.serviceNames.indexOf(serviceName) < 0) {
-        return false;
+        return !inclusion;
     }
 
     ids[frame.id] = true;
 
-    return true;
+    return inclusion;
 };
 
 //
@@ -143,6 +169,7 @@ Arg1Filter.prototype.take = function take(filter) {
         return false;
     } else {
         self.arg1Methods = {};
+        self.inclusion = inclusionValidate(filter, 'Arg1 filters');
         filter.forEach(function arr2obj(name) {
             self.arg1Methods[name] = true;
         });
@@ -151,15 +178,16 @@ Arg1Filter.prototype.take = function take(filter) {
     }
 };
 
-Arg1Filter.prototype.process = function process(handle, frame) {
+Arg1Filter.prototype.process = function processEx(handle, frame) {
     var self = this;
+    var inclusion = !!self.inclusion;
 
     // arg1 only applies to the following types
     if (frame.body.type !== FrameTypes.CallRequest &&
         frame.body.type !== FrameTypes.CallResponse &&
         frame.body.type !== FrameTypes.CallRequestCont &&
         frame.body.type !== FrameTypes.CallResponseCont) {
-        return false;
+        return !inclusion;
     }
 
     if (!handle.arg1) {
@@ -168,7 +196,7 @@ Arg1Filter.prototype.process = function process(handle, frame) {
 
     if (!frame.body.args) {
         // filter out frames not related
-        return false;
+        return !inclusion;
     }
 
     var ids = handle.arg1;
@@ -177,17 +205,21 @@ Arg1Filter.prototype.process = function process(handle, frame) {
             delete ids[frame.id];
         }
 
-        return true;
+        return inclusion;
     }
 
     var name = frame.body.args[0];
+    if (!inclusion) {
+        name = '~' + name;
+    }
+
     if (!self.arg1Methods[name]) {
-        return false;
+        return !inclusion;
     }
 
     ids[frame.id] = true;
 
-    return true;
+    return inclusion;
 };
 
 //
@@ -292,7 +324,3 @@ Arg1Matcher.prototype.process = function process(handle, frame) {
 
     return true;
 };
-
-
-
-


### PR DESCRIPTION
r @kriskowal @blampe @anson627 

Test with node/examples/example1.js

tcap.js -i lo0 -i en0 -p 4040 -p 4041 -p 8065 -s ~server
listening on interface lo0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
listening on interface en0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
session=0 started src=127.0.0.1:60221 --> dst=127.0.0.1:4040 on lo0
session=0 127.0.0.1:60221 --> 127.0.0.1:4040 frame=1 type=0x01
INIT REQUEST id=0x0001 (1) version=2
headers
  host_port: 0.0.0.0:0
  process_name: node[5085]

session=0 127.0.0.1:60221 <-- 127.0.0.1:4040 frame=1 type=0x02
INIT RESPONSE id=0x0001 (1) version=2
headers
  host_port: 127.0.0.1:4040
  process_name: node[5085]

session=0 ended src=127.0.0.1:60221 --> dst=127.0.0.1:4040 on lo0


tcap.js -i lo0 -i en0 -p 4040 -p 4041 -p 8065 -p 4000-6000 -1 ~func1
listening on interface lo0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
listening on interface en0 with filter ip proto \tcp and (port 4040 or port 4041 or port 8065 or portrange 4000-6000)
session=0 started src=127.0.0.1:61790 --> dst=127.0.0.1:4040 on lo0
session=0 127.0.0.1:61790 --> 127.0.0.1:4040 frame=1 type=0x01
INIT REQUEST id=0x0001 (1) version=2
headers
  host_port: 0.0.0.0:0
  process_name: node[6484]

session=0 127.0.0.1:61790 <-- 127.0.0.1:4040 frame=1 type=0x02
INIT RESPONSE id=0x0001 (1) version=2
headers
  host_port: 127.0.0.1:4040
  process_name: node[6484]

session=0 127.0.0.1:61790 --> 127.0.0.1:4040 frame=3 type=0x03
CALL REQUEST id=0x0003 (3) service="server" flags=0x00 ttl=0x0064 (100)
headers
  cn: example-client
  as: raw
  re: c
tracing: spanid=5627b7e9b22198f2 parentid=0000000000000000 traceid=5627b7e9b22198f2 flags=0x00
args[0]
    00: 6675 6e63 32                             func2
args[1]
    00: 6172 6720 31                             arg 1
args[2]
    00: 6172 6720 32                             arg 2

session=0 127.0.0.1:61790 <-- 127.0.0.1:4040 frame=3 type=0x04 NotOk
CALL RESPONSE id=0x0003 (3) flags=0x00
headers
  as: raw
tracing: spanid=5627b7e9b22198f2 parentid=0000000000000000 traceid=5627b7e9b22198f2 flags=0x00
args[0]
    00:                                          empty
args[1]
    00:                                          empty
args[2]
    00: 6974 2066 6169 6c65 64                   it failed

session=0 ended src=127.0.0.1:61790 --> dst=127.0.0.1:4040 on lo0

